### PR TITLE
Fix issues with file processing when creating zip source file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+modules/data_pipeline/temp/
 modules/data_pipeline/files/
 modules/export_pipeline/files/

--- a/modules/data_pipeline/main.tf
+++ b/modules/data_pipeline/main.tf
@@ -29,7 +29,7 @@ resource "local_file" "to_temp_dir_root" {
   content  = file(element(data.template_file.t_file.*.rendered, count.index))
 }
 
-# Copy /wheels files to temp directoryg
+# Copy /wheels files to temp directory
 resource "local_file" "to_temp_dir_wheels" {
   count = "${length(local.wheels_source_files)}"
 
@@ -38,7 +38,7 @@ resource "local_file" "to_temp_dir_wheels" {
   content_base64 = filebase64("${local.wheels_dir}${element(local.wheels_source_files, count.index)}")
 }
 
-# Process /usl_lib files
+# Copy /url_lib files to temp directory
 resource "local_file" "to_temp_dir_usl_lib" {
   count = length(local.usl_lib_source_files)
 

--- a/modules/data_pipeline/main.tf
+++ b/modules/data_pipeline/main.tf
@@ -2,42 +2,48 @@ data "google_project" "project" {
 }
 
 locals {
-  source_files = concat(
-    # Add paths to files from /cloud_functions's root
-    [
+  root_source_files =  [
       "${path.module}/../../climateiq-cnn/usl_pipeline/cloud_functions/main.py",
       "${path.module}/../../climateiq-cnn/usl_pipeline/cloud_functions/requirements.txt"
-    ],
-    # Add paths to all .py files from /usl_lib subdirectory
-    tolist(fileset("${path.module}/../../climateiq-cnn/usl_pipeline/usl_lib/usl_lib/", "**/*.py")),
-    # Add paths to all .whl files from /cloud_functions's /wheels subdirectory
-    tolist(fileset("${path.module}/../../climateiq-cnn/usl_pipeline/cloud_functions/wheels/", "*.whl"))
-  )
+  ]
+  wheels_source_files = tolist(fileset("{path.module}/../../climateiq-cnn/usl_pipeline/cloud_functions/wheels/", "*.whl"))
+  usl_lib_source_files = tolist(fileset("${path.module}/../../climateiq-cnn/usl_pipeline/usl_lib/usl_lib/", "**/*.py"))
 
-  usl_lib_dir = "${path.module}/../../climateiq-cnn/usl_pipeline/usl_lib/usl_lib/"
   wheels_dir = "${path.module}/../../climateiq-cnn/usl_pipeline/cloud_functions/wheels/"
+  usl_lib_dir = "${path.module}/../../climateiq-cnn/usl_pipeline/usl_lib/usl_lib/"
 }
 
-# Read and process the content from source_files
+# Process and copy files root cloud function files to temp directory.
+# A `template_file` data block is used here to first process each files content
+# and make it available to use elsewhere in this file. This is necessary for files
+# defined in `locals` block that is not dynamically discovered (i.e. fileset()).
 data "template_file" "t_file" {
-  count = "${length(local.source_files)}"
-  template = element(local.source_files, count.index)
+  count = "${length(local.root_source_files)}"
+  template = "${element(local.root_source_files, count.index)}"
 }
 
-# Copy files to a temporary directory to prep for zip
-resource "local_file" "to_temp_dir" {
-  count    = "${length(local.source_files)}"
+resource "local_file" "to_temp_dir_root" {
+  count = "${length(local.root_source_files)}"
 
-  # Filenames are constructed to preserve source subdirectory structure within /temp
-  filename = "${path.module}/temp/${
-    contains(fileset(local.usl_lib_dir, "**/"), element(local.source_files, count.index)) ?        
-      "usl_lib/${element(local.source_files, count.index)}" : 
-    contains(fileset(local.wheels_dir, "*"), element(local.source_files, count.index)) ? 
-      "wheels/${element(local.source_files, count.index)}" :
-    basename(element(local.source_files, count.index))
-  }"
+  filename = "${path.module}/temp/${basename(element(local.root_source_files, count.index))}"
+  content  = file(element(data.template_file.t_file.*.rendered, count.index))
+}
 
-  content  = "${element(data.template_file.t_file.*.rendered, count.index)}"
+# Copy /wheels files to temp directoryg
+resource "local_file" "to_temp_dir_wheels" {
+  count = "${length(local.wheels_source_files)}"
+
+  filename = "${path.module}/temp/wheels/${basename(element(local.wheels_source_files, count.index))}"
+  # Use base64 since wheel files are binary
+  content_base64 = filebase64("${local.wheels_dir}${element(local.wheels_source_files, count.index)}")
+}
+
+# Process /usl_lib files
+resource "local_file" "to_temp_dir_usl_lib" {
+  count = length(local.usl_lib_source_files)
+
+  filename = "${path.module}/temp/usl_lib/${element(local.usl_lib_source_files, count.index)}"
+  content  = file("${local.usl_lib_dir}${element(local.usl_lib_source_files, count.index)}")
 }
 
 # Place the source code for the cloud function into a GCS bucket.
@@ -47,7 +53,9 @@ data "archive_file" "source" {
   source_dir  = "${path.module}/temp"
 
   depends_on = [
-    local_file.to_temp_dir,
+    local_file.to_temp_dir_root,
+    local_file.to_temp_dir_wheels,
+    local_file.to_temp_dir_usl_lib,
   ]
 }
 


### PR DESCRIPTION
Refactor to use separate resource blocks for:
1. "root files" - main.py, requirements.txt
2. "wheel files" - wheels in /wheels
3. "usl lib files" - py files in /usl_lib

Each set of source files need to be processed and packaged slightly differently, depending on file type and the way we identify the files. For example, files pulled in via `fileset` are dynamically discovered and need to be referenced differently from files like main.py.

Additionally, wheel files will use `content_base64` instead of `content` in the resource block since wheel files will be binary files.
